### PR TITLE
update: Set north by value

### DIFF
--- a/RelativeHMC6352.cpp
+++ b/RelativeHMC6352.cpp
@@ -3,6 +3,7 @@
 
 RelativeHMC6352::RelativeHMC6352()
 {
+    Wire.begin();
     _north = 0.0;
 }
 
@@ -43,8 +44,13 @@ float RelativeHMC6352::angle()
 
 void RelativeHMC6352::set_north()
 {
-    Wire.begin();
     _north = RelativeHMC6352::angle_raw();
+}
+
+void RelativeHMC6352::set_north_val(float val)
+{
+    val = fmod(val, 360.0);
+    _north = val < 0 ? val + 360.0 : val;
 }
 
 float RelativeHMC6352::real_north()

--- a/RelativeHMC6352.h
+++ b/RelativeHMC6352.h
@@ -16,6 +16,7 @@ class RelativeHMC6352
 	public:
 		RelativeHMC6352();
         void set_north();
+        void set_north_val(float val);
         float real_north();
         float angle_raw();
         float angle();


### PR DESCRIPTION
- Add function for setting north by value
- Call Wire.begin only once

Signed-off-by: vargac simon.varga123@gmail.com
